### PR TITLE
Feature/rds deploy

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -18,5 +18,6 @@ pipeline:
     secrets:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
+      - SSH_KEY
     when:
       event: push

--- a/.drone.yml
+++ b/.drone.yml
@@ -11,7 +11,10 @@ pipeline:
 
   run-testrunner-tests:
     image: quay.io/ukhomeofficedigital/tf-testrunner
-    commands: python -m unittest tests/*_test.py
+    commands: 
+      - mkdir /root/.ssh && echo "$SSH_KEY" > /root/.ssh/id_rsa && chmod 0600 /root/.ssh/id_rsa
+      - ssh-keyscan -t rsa -p 2222 gitlab.digital.homeoffice.gov.uk >>  ~/.ssh/known_hosts
+      - python -m unittest tests/*_test.py
     secrets:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY

--- a/main.tf
+++ b/main.tf
@@ -127,7 +127,6 @@ module "rds_deploy" {
   lambda_subnet                    = "${module.lambda.lambda_subnet}"
   lambda_subnet_az2                = "${module.lambda.lambda_subnet_az2}"
   lambda_sgrp                      = "${module.lambda.lambda_sgrp}"
-  pipeline_count                   = "${var.pipeline_count}"
   naming_suffix                    = "${local.naming_suffix}"
   namespace                        = "${var.naming_suffix}"
 }

--- a/main.tf
+++ b/main.tf
@@ -127,6 +127,9 @@ module "rds_deploy" {
   lambda_subnet                    = "${module.lambda.lambda_subnet}"
   lambda_subnet_az2                = "${module.lambda.lambda_subnet_az2}"
   lambda_sgrp                      = "${module.lambda.lambda_sgrp}"
+  rds_db_name                      = "${var.rds_db_name}"
+  rds_endpoint                     = "${var.rds_endpoint}"
+  rds_instance                     = "${var.rds_instance}"
   naming_suffix                    = "${local.naming_suffix}"
   namespace                        = "${var.naming_suffix}"
 }

--- a/main.tf
+++ b/main.tf
@@ -122,6 +122,16 @@ module "lambda" {
   route_table_id                   = "${aws_route_table.apps_route_table.id}"
 }
 
+module "rds_deploy" {
+  source                           = "git::ssh://git@gitlab.digital.homeoffice.gov.uk:2222/dacc-dq/dq-tf-rds-deploy.git?ref=feature/module_source"
+  lambda_subnet                    = "${module.lambda.lambda_subnet}"
+  lambda_subnet_az2                = "${module.lambda.lambda_subnet_az2}"
+  lambda_sgrp                      = "${module.lambda.lambda_sgrp}"
+  pipeline_count                   = "${var.pipeline_count}"
+  naming_suffix                    = "${local.naming_suffix}"
+  namespace                        = "${var.naming_suffix}"
+}
+
 resource "aws_vpc" "appsvpc" {
   cidr_block           = "${var.cidr_block}"
   enable_dns_hostnames = true

--- a/main.tf
+++ b/main.tf
@@ -123,7 +123,7 @@ module "lambda" {
 }
 
 module "rds_deploy" {
-  source                           = "git::ssh://git@gitlab.digital.homeoffice.gov.uk:2222/dacc-dq/dq-tf-rds-deploy.git?ref=feature/module_source"
+  source                           = "git::ssh://git@gitlab.digital.homeoffice.gov.uk:2222/dacc-dq/dq-tf-rds-deploy.git"
   lambda_subnet                    = "${module.lambda.lambda_subnet}"
   lambda_subnet_az2                = "${module.lambda.lambda_subnet_az2}"
   lambda_sgrp                      = "${module.lambda.lambda_sgrp}"

--- a/tests/apps_test.py
+++ b/tests/apps_test.py
@@ -137,5 +137,14 @@ class TestE2E(unittest.TestCase):
     def test_name_suffix_nats_iam_user(self):
         self.assertEqual(self.result['apps']["aws_iam_user.nats"]["name"], "iam-user-nats-apps-preprod-dq")
 
+    def test_name_suffix_rds_deploy_iam_lambda_rds(self):
+        self.assertEqual(self.result['apps']['rds_deploy']["aws_iam_role.lambda_rds"]["tags.Name"], "iam-lambda-rds-deploy-apps-preprod-dq")
+
+    def test_name_suffix_rds_deploy_lambda_function(self):
+        self.assertEqual(self.result['apps']['rds_deploy']["aws_lambda_function.lambda_rds"]["tags.Name"], "lambda-rds-deploy-apps-preprod-dq")
+
+    def test_name_suffix_rds_deploy_cloudwatch_log_group(self):
+        self.assertEqual(self.result['apps']['rds_deploy']["aws_cloudwatch_log_group.lambda_rds"]["tags.Name"], "lambda-rds-deploy-apps-preprod-dq")
+
 if __name__ == '__main__':
     unittest.main()

--- a/variables.tf
+++ b/variables.tf
@@ -38,3 +38,18 @@ variable "s3_bucket_acl" {
   description = "Map of the S3 bucket canned ACLs"
   type        = "map"
 }
+
+variable "rds_instance" {
+  description = "The logical name of the RDS instance for a Postgres deployment to run against" 
+  default     = "internal_tableau"
+}
+
+variable "rds_endpoint" {
+  description = "The RDS endpoint that the Postgres deployment will be run against"
+  default     = "int-tableau-postgres-internal-tableau-apps-test-dq.czqp9ptbtrmd.eu-west-2.rds.amazonaws.com"
+}
+
+variable "rds_db_name" {
+  description = "Supplies the database name for a Postgres deployment"
+  default     = "internal_tableau"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -38,7 +38,3 @@ variable "s3_bucket_acl" {
   description = "Map of the S3 bucket canned ACLs"
   type        = "map"
 }
-
-variable "pipeline_count" {
-  default = 1
-}

--- a/variables.tf
+++ b/variables.tf
@@ -38,3 +38,7 @@ variable "s3_bucket_acl" {
   description = "Map of the S3 bucket canned ACLs"
   type        = "map"
 }
+
+variable "pipeline_count" {
+  default = 1
+}


### PR DESCRIPTION
Sources the dq-tf-rds-deploy GitLab repo. GitHub Drone access the repo via a new deployment key created in GitLab. The key pair are stored in NotProd SSM.