### PR TITLE
Feature/airports input

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -122,6 +122,12 @@ module "lambda" {
   route_table_id                   = "${aws_route_table.apps_route_table.id}"
 }
 
+module "airports_input_pipeline" {
+  source         = "git::ssh://git@gitlab.digital.homeoffice.gov.uk:2222/dacc-dq/dq-tf-airports-input.git"
+  naming_suffix  = "${local.naming_suffix}"
+  namespace      = "${var.namespace}"
+}
+
 module "rds_deploy" {
   source                           = "git::ssh://git@gitlab.digital.homeoffice.gov.uk:2222/dacc-dq/dq-tf-rds-deploy.git"
   lambda_subnet                    = "${module.lambda.lambda_subnet}"

--- a/tests/apps_test.py
+++ b/tests/apps_test.py
@@ -30,6 +30,7 @@ class TestE2E(unittest.TestCase):
               ad_aws_ssm_document_name        = "1234"
               ad_writer_instance_profile_name = "1234"
               naming_suffix                   = "preprod-dq"
+              namespace                       = "preprod"
               haproxy_private_ip              = "1.2.3.3"
               haproxy_private_ip2             = "1.2.3.4"
 
@@ -172,6 +173,31 @@ class TestE2E(unittest.TestCase):
 
     def test_name_oag_iam_user(self):
         self.assertEqual(self.result['apps']["aws_iam_user.oag"]["name"], "iam-user-oag-apps-preprod-dq")
+
+    def test_name_suffix_airports_input_pipeline_lambda_athena(self):
+        self.assertEqual(self.result['apps']['airports_input_pipeline']["aws_lambda_function.lambda_athena"]["tags.Name"], "lambda-athena-airports-input-apps-preprod-dq")
+
+    def test_name_suffix_airports_input_pipeline_iam_lambda_trigger(self):
+        self.assertEqual(self.result['apps']['airports_input_pipeline']["aws_iam_role.lambda_trigger"]["tags.Name"], "iam-lambda-trigger-airports-input-apps-preprod-dq")
+
+    def test_name_suffix_airports_input_pipeline_ssm_lambda_trigger(self):
+        self.assertEqual(self.result['apps']['airports_input_pipeline']["aws_ssm_parameter.lambda_trigger_enabled"]["tags.Name"], "ssm-lambda-trigger-enabled-airports-input-apps-preprod-dq")
+
+    def test_name_suffix_airports_input_pipeline_iam_lambda_athena(self):
+        self.assertEqual(self.result['apps']['airports_input_pipeline']["aws_iam_role.lambda_athena"]["tags.Name"], "iam-lambda-athena-airports-input-apps-preprod-dq")
+
+    def test_name_suffix_airports_input_pipeline_log_lambda_athena(self):
+        self.assertEqual(self.result['apps']['airports_input_pipeline']["aws_cloudwatch_log_group.lambda_athena"]["tags.Name"], "log-lambda-athena-airports-input-apps-preprod-dq")
+
+    def test_name_suffix_airports_input_pipeline_sfn_state_machine(self):
+        self.assertEqual(self.result['apps']['airports_input_pipeline']["aws_sfn_state_machine.sfn_state_machine"]["tags.Name"], "sfn-state-machine-airports-input-apps-preprod-dq")
+
+    def test_name_suffix_airports_input_pipeline_lambda_trigger(self):
+        self.assertEqual(self.result['apps']['airports_input_pipeline']["aws_lambda_function.lambda_trigger"]["tags.Name"], "lambda-trigger-airports-input-apps-preprod-dq")
+
+    def test_name_suffix_airports_input_pipeline_log_lambda_trigger(self):
+        self.assertEqual(self.result['apps']['airports_input_pipeline']["aws_cloudwatch_log_group.lambda_trigger"]["tags.Name"], "log-lambda-trigger-airports-input-apps-preprod-dq")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/apps_test.py
+++ b/tests/apps_test.py
@@ -174,30 +174,6 @@ class TestE2E(unittest.TestCase):
     def test_name_oag_iam_user(self):
         self.assertEqual(self.result['apps']["aws_iam_user.oag"]["name"], "iam-user-oag-apps-preprod-dq")
 
-    def test_name_suffix_airports_input_pipeline_lambda_athena(self):
-        self.assertEqual(self.result['apps']['airports_input_pipeline']["aws_lambda_function.lambda_athena"]["tags.Name"], "lambda-athena-airports-input-apps-preprod-dq")
-
-    def test_name_suffix_airports_input_pipeline_iam_lambda_trigger(self):
-        self.assertEqual(self.result['apps']['airports_input_pipeline']["aws_iam_role.lambda_trigger"]["tags.Name"], "iam-lambda-trigger-airports-input-apps-preprod-dq")
-
-    def test_name_suffix_airports_input_pipeline_ssm_lambda_trigger(self):
-        self.assertEqual(self.result['apps']['airports_input_pipeline']["aws_ssm_parameter.lambda_trigger_enabled"]["tags.Name"], "ssm-lambda-trigger-enabled-airports-input-apps-preprod-dq")
-
-    def test_name_suffix_airports_input_pipeline_iam_lambda_athena(self):
-        self.assertEqual(self.result['apps']['airports_input_pipeline']["aws_iam_role.lambda_athena"]["tags.Name"], "iam-lambda-athena-airports-input-apps-preprod-dq")
-
-    def test_name_suffix_airports_input_pipeline_log_lambda_athena(self):
-        self.assertEqual(self.result['apps']['airports_input_pipeline']["aws_cloudwatch_log_group.lambda_athena"]["tags.Name"], "log-lambda-athena-airports-input-apps-preprod-dq")
-
-    def test_name_suffix_airports_input_pipeline_sfn_state_machine(self):
-        self.assertEqual(self.result['apps']['airports_input_pipeline']["aws_sfn_state_machine.sfn_state_machine"]["tags.Name"], "sfn-state-machine-airports-input-apps-preprod-dq")
-
-    def test_name_suffix_airports_input_pipeline_lambda_trigger(self):
-        self.assertEqual(self.result['apps']['airports_input_pipeline']["aws_lambda_function.lambda_trigger"]["tags.Name"], "lambda-trigger-airports-input-apps-preprod-dq")
-
-    def test_name_suffix_airports_input_pipeline_log_lambda_trigger(self):
-        self.assertEqual(self.result['apps']['airports_input_pipeline']["aws_cloudwatch_log_group.lambda_trigger"]["tags.Name"], "log-lambda-trigger-airports-input-apps-preprod-dq")
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,7 @@ variable "ad_writer_instance_profile_name" {}
 variable "naming_suffix" {}
 variable "haproxy_private_ip" {}
 variable "haproxy_private_ip2" {}
+variable "namespace" {}
 
 variable "ad_sg_cidr_ingress" {
   description = "List of CIDR block ingress to AD machines SG"
@@ -44,4 +45,3 @@ variable "rds_db_name" {
   default     = "internal_tableau"
 }
 
-variable "namespace" {}

--- a/variables.tf
+++ b/variables.tf
@@ -43,3 +43,5 @@ variable "rds_db_name" {
   description = "Supplies the database name for a Postgres deployment"
   default     = "internal_tableau"
 }
+
+variable "namespace" {}


### PR DESCRIPTION
Adds airports input pipelines and associated tests. See PR on dq-tf-infra which will need to be merged after merging this PR but before running dq-tf-infra again, in order for namespace to be passed in.