### PR TITLE
Feature/airports

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -122,6 +122,18 @@ module "lambda" {
   route_table_id                   = "${aws_route_table.apps_route_table.id}"
 }
 
+module "airports_pipeline" {
+  source                             = "git::ssh://git@gitlab.digital.homeoffice.gov.uk:2222/dacc-dq/dq-tf-airports-pipeline.git"
+  kms_key_s3                         = "${aws_kms_key.bucket_key.arn}"
+  lambda_subnet                      = "${module.lambda.lambda_subnet}"
+  lambda_subnet_az2                  = "${module.lambda.lambda_subnet_az2}"
+  lambda_sgrp                        = "${module.lambda.lambda_sgrp}"
+  rds_db_name                        = "${var.rds_db_name}"
+  rds_internal_tableau_address       = "${module.internal_tableau.rds_internal_tableau_address}"
+  naming_suffix                      = "${local.naming_suffix}"
+  namespace                          = "${var.namespace}"
+}
+
 module "airports_input_pipeline" {
   source         = "git::ssh://git@gitlab.digital.homeoffice.gov.uk:2222/dacc-dq/dq-tf-airports-input.git"
   naming_suffix  = "${local.naming_suffix}"

--- a/main.tf
+++ b/main.tf
@@ -122,6 +122,12 @@ module "lambda" {
   route_table_id                   = "${aws_route_table.apps_route_table.id}"
 }
 
+module "airports_input_pipeline" {
+  source         = "git::ssh://git@gitlab.digital.homeoffice.gov.uk:2222/dacc-dq/dq-tf-airports-input.git"
+  naming_suffix  = "${local.naming_suffix}"
+  namespace      = "${var.namespace}"
+}
+
 module "rds_deploy" {
   source                           = "git::ssh://git@gitlab.digital.homeoffice.gov.uk:2222/dacc-dq/dq-tf-rds-deploy.git"
   lambda_subnet                    = "${module.lambda.lambda_subnet}"

--- a/tests/apps_test.py
+++ b/tests/apps_test.py
@@ -198,6 +198,43 @@ class TestE2E(unittest.TestCase):
     def test_name_suffix_airports_input_pipeline_log_lambda_trigger(self):
         self.assertEqual(self.result['apps']['airports_input_pipeline']["aws_cloudwatch_log_group.lambda_trigger"]["tags.Name"], "log-lambda-trigger-airports-input-apps-preprod-dq")
 
+    def test_name_suffix_airports_pipeline_iam_lambda_trigger(self):
+        self.assertEqual(self.result['apps']['airports_pipeline']["aws_iam_role.lambda_trigger"]["tags.Name"], "iam-lambda-trigger-airports-apps-preprod-dq")
+
+    def test_name_suffix_airports_pipeline_iam_lambda_athena(self):
+        self.assertEqual(self.result['apps']['airports_pipeline']["aws_iam_role.lambda_athena"]["tags.Name"], "iam-lambda-athena-airports-apps-preprod-dq")
+
+    def test_name_suffix_airports_pipeline_iam_lambda_rds(self):
+        self.assertEqual(self.result['apps']['airports_pipeline']["aws_iam_role.lambda_rds"]["tags.Name"], "iam-lambda-rds-airports-apps-preprod-dq")
+
+    def test_name_suffix_airports_pipeline_step_function_exec(self):
+        self.assertEqual(self.result['apps']['airports_pipeline']["aws_iam_role.step_function_exec"]["tags.Name"], "step-function-exec-airports-apps-preprod-dq")
+
+    def test_name_suffix_airports_pipeline_lambda_trigger_enabled(self):
+        self.assertEqual(self.result['apps']['airports_pipeline']["aws_ssm_parameter.lambda_trigger_enabled"]["tags.Name"], "ssm-lambda-trigger-enabled-airports-apps-preprod-dq")
+
+    def test_name_suffix_airports_pipeline_lambda_athena(self):
+        self.assertEqual(self.result['apps']['airports_pipeline']["aws_lambda_function.lambda_athena"]["tags.Name"], "lambda-athena-airports-apps-preprod-dq")
+
+    def test_name_suffix_airports_pipeline_lambda_trigger(self):
+        self.assertEqual(self.result['apps']['airports_pipeline']["aws_lambda_function.lambda_trigger"]["tags.Name"], "lambda-trigger-airports-apps-preprod-dq")
+
+    def test_name_suffix_airports_pipeline_lambda_rds(self):
+        self.assertEqual(self.result['apps']['airports_pipeline']["aws_lambda_function.lambda_rds"]["tags.Name"], "lambda-rds-airports-apps-preprod-dq")
+
+    def test_name_suffix_airports_pipeline_log_lambda_athena(self):
+        self.assertEqual(self.result['apps']['airports_pipeline']["aws_cloudwatch_log_group.lambda_athena"]["tags.Name"], "log-lambda-athena-airports-apps-preprod-dq")
+
+    def test_name_suffix_airports_pipeline_log_lambda_rds(self):
+        self.assertEqual(self.result['apps']['airports_pipeline']["aws_cloudwatch_log_group.lambda_rds"]["tags.Name"], "log-lambda-rds-airports-apps-preprod-dq")
+
+    def test_name_suffix_airports_pipeline_log_lambda_trigger(self):
+        self.assertEqual(self.result['apps']['airports_pipeline']["aws_cloudwatch_log_group.lambda_trigger"]["tags.Name"], "log-lambda-trigger-airports-apps-preprod-dq")
+
+    def test_name_suffix_airports_pipeline_sfn_state_machine(self):
+        self.assertEqual(self.result['apps']['airports_pipeline']["aws_sfn_state_machine.sfn_state_machine"]["tags.Name"], "sfn-state-machine-airports-apps-preprod-dq")
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/variables.tf
+++ b/variables.tf
@@ -43,3 +43,5 @@ variable "rds_db_name" {
   description = "Supplies the database name for a Postgres deployment"
   default     = "internal_tableau"
 }
+
+variable "namespace" {}


### PR DESCRIPTION
This should be merged after https://github.com/UKHomeOffice/dq-tf-apps/pull/123 and https://github.com/UKHomeOffice/dq-tf-infra/pull/81

This adds the airports pipeline and tests. Note this is separate from the airports-input pipeline and this PR assumes the airports input pipeline has been done first.