### PR TITLE
Pass glue kms key to pipelines.

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -33,3 +33,7 @@ data "aws_ami" "rhel" {
 }
 
 data "aws_caller_identity" "current" {}
+
+data "aws_kms_key" "glue" {
+  key_id = "alias/aws/glue"
+}

--- a/main.tf
+++ b/main.tf
@@ -125,6 +125,7 @@ module "lambda" {
 module "airports_pipeline" {
   source            = "git::ssh://git@gitlab.digital.homeoffice.gov.uk:2222/dacc-dq/dq-tf-airports-pipeline.git"
   kms_key_s3        = "${aws_kms_key.bucket_key.arn}"
+  kms_key_glue      = "${data.aws_kms_key.glue.arn}"
   lambda_subnet     = "${module.lambda.lambda_subnet}"
   lambda_subnet_az2 = "${module.lambda.lambda_subnet_az2}"
   lambda_sgrp       = "${module.lambda.lambda_sgrp}"
@@ -137,6 +138,7 @@ module "airports_pipeline" {
 module "airports_input_pipeline" {
   source        = "git::ssh://git@gitlab.digital.homeoffice.gov.uk:2222/dacc-dq/dq-tf-airports-input.git"
   kms_key_s3    = "${aws_kms_key.bucket_key.arn}"
+  kms_key_glue  = "${data.aws_kms_key.glue.arn}"
   naming_suffix = "${local.naming_suffix}"
   namespace     = "${var.namespace}"
 }


### PR DESCRIPTION
Pass KMS key to pipelines so they can reference it consistently in policies.