### PR TITLE
Add dq-pipeline-ops group with suitable access levels for operations.

### DIFF
--- a/iam_pipeline_ops.tf
+++ b/iam_pipeline_ops.tf
@@ -1,0 +1,109 @@
+resource "aws_iam_policy" "dq_pipeline_ops_policy" {
+  name = "dq-pipeline-ops-policy-${var.namespace}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+                "s3:GetBucketLocation",
+                "s3:GetObject",
+                "s3:ListBucket",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListMultipartUploadParts",
+                "s3:AbortMultipartUpload",
+                "s3:PutObject",
+                "s3:DeleteObject"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "${join("\",\"",formatlist("arn:aws:s3:::%s-%s", var.dq_pipeline_ops_readwrite_bucket_list, var.namespace))}",
+        "${join("\",\"",formatlist("arn:aws:s3:::%s-%s/*", var.dq_pipeline_ops_readwrite_bucket_list, var.namespace))}"
+      ]
+    },
+    {
+      "Action": [
+                "s3:GetBucketLocation",
+                "s3:GetObject",
+                "s3:ListBucket"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "${join("\",\"",formatlist("arn:aws:s3:::%s-%s", var.dq_pipeline_ops_readonly_bucket_list, var.namespace))}",
+        "${join("\",\"",formatlist("arn:aws:s3:::%s-%s/*", var.dq_pipeline_ops_readonly_bucket_list, var.namespace))}"
+      ]
+    },
+    {
+      "Action": [
+        "athena:StartQueryExecution",
+        "athena:GetQueryExecution"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
+        "glue:GetDatabase",
+        "glue:CreateTable",
+        "glue:DeleteTable",
+        "glue:GetTable",
+        "glue:GetPartition",
+        "glue:GetPartitions",
+        "glue:BatchCreatePartition",
+        "glue:BatchDeletePartition"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:glue:eu-west-2:${data.aws_caller_identity.current.account_id}:catalog",
+        "${join("\",\"",formatlist("arn:aws:glue:eu-west-2:${data.aws_caller_identity.current.account_id}:database/%s_%s", var.dq_pipeline_ops_readwrite_database_name_list, var.namespace))}",
+        "${join("\",\"",formatlist("arn:aws:glue:eu-west-2:${data.aws_caller_identity.current.account_id}:table/%s_%s/*", var.dq_pipeline_ops_readwrite_database_name_list, var.namespace))}"
+      ]
+    },
+    {
+      "Action": [
+        "glue:GetDatabase",
+        "glue:GetTable",
+        "glue:GetPartition",
+        "glue:GetPartitions"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:glue:eu-west-2:${data.aws_caller_identity.current.account_id}:database/default",
+        "${join("\",\"",formatlist("arn:aws:glue:eu-west-2:${data.aws_caller_identity.current.account_id}:database/%s_%s", var.dq_pipeline_ops_readonly_database_name_list, var.namespace))}",
+        "${join("\",\"",formatlist("arn:aws:glue:eu-west-2:${data.aws_caller_identity.current.account_id}:table/%s_%s/*", var.dq_pipeline_ops_readonly_database_name_list, var.namespace))}"
+      ]
+    },
+    {
+      "Action": [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey"
+      ],
+      "Effect": "Allow",
+      "Resource": "${aws_kms_key.bucket_key.arn}"
+    },
+    {
+      "Action": [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:GenerateDataKey"
+      ],
+      "Effect": "Allow",
+      "Resource": "${data.aws_kms_key.glue.arn}"
+    }
+  ]
+}
+EOF
+
+}
+
+resource "aws_iam_group" "dq_pipeline_ops_group" {
+  name = "dq-pipeline-ops-${var.namespace}"
+}
+
+resource "aws_iam_group_policy_attachment" "dq_pipeline_ops_attachment" {
+  group      = "${aws_iam_group.dq_pipeline_ops_group.name}"
+  policy_arn = "${aws_iam_policy.dq_pipeline_ops_policy.arn}"
+}

--- a/tests/apps_test.py
+++ b/tests/apps_test.py
@@ -418,5 +418,11 @@ class TestE2E(unittest.TestCase):
     def test_name_suffix_internal_reporting_pipeline_log_lambda_rds(self):
         self.assertEqual(self.result['apps']['internal_reporting_pipeline']["aws_cloudwatch_log_group.lambda_rds"]["tags.Name"], "log-lambda-rds-internal-reporting-apps-preprod-dq")
 
+    def test_name_suffix_dq_pipeline_ops_group(self):
+        self.assertEqual(self.result['apps']["aws_iam_group.dq_pipeline_ops_group"]["name"], "dq-pipeline-ops-preprod")
+
+    def test_name_suffix_dq_pipeline_ops_policy(self):
+        self.assertEqual(self.result['apps']["aws_iam_policy.dq_pipeline_ops_policy"]["name"], "dq-pipeline-ops-policy-preprod")
+
 if __name__ == '__main__':
     unittest.main()

--- a/variables.tf
+++ b/variables.tf
@@ -44,3 +44,34 @@ variable "rds_db_name" {
   description = "Supplies the database name for a Postgres deployment"
   default     = "internal_tableau"
 }
+
+variable "dq_pipeline_ops_readwrite_database_name_list" {
+  default = ["reference_data",
+             "acl",
+             "consolidated_schedule",
+             "api_record_level_score",
+             "api_cross_record_scored",
+             "api_input",
+             "oag_transform",
+             "internal_reporting"]
+}
+
+variable "dq_pipeline_ops_readonly_database_name_list" {
+  default = ["api_input"]
+}
+
+variable "dq_pipeline_ops_readwrite_bucket_list" {
+  default = ["s3-dq-reference-data-internal",
+             "s3-dq-acl-internal",
+             "s3-dq-oag-internal",
+             "s3-dq-oag-transform",
+             "s3-dq-consolidated-schedule",
+             "s3-dq-api-record-level-scoring",
+             "s3-dq-api-internal",
+             "s3-dq-cross-record-scored",
+             "s3-dq-raw-file-index-internal"]
+}
+
+variable "dq_pipeline_ops_readonly_bucket_list" {
+  default = ["s3-dq-api-internal"]
+}


### PR DESCRIPTION
This group and policy defines the level of access for users operating the new pipeline solution.
Note that groups and standard policies can't be tagged so the tests use the names directly.