### PR TITLE
Adding downloadable permission for user

### DIFF
--- a/iam_data_archive.tf
+++ b/iam_data_archive.tf
@@ -23,7 +23,10 @@ resource "aws_iam_group_policy" "data_archive_bucket" {
       "Resource": "${aws_s3_bucket.data_archive_bucket.arn}"
     },
     {
-      "Action": "s3:PutObject",
+      "Action": [
+        "s3:PutObject",
+        "s3:GetObject"
+      ],
       "Effect": "Allow",
       "Resource": "${aws_s3_bucket.data_archive_bucket.arn}/*"
     },


### PR DESCRIPTION
Jira S3 backup user is currently not able to download the backup from S3 location. Which unable to restore the jira from S3-backup container. This permission is a must.