### PR TITLE
Ad password bug

### DIFF
--- a/tests/apps_test.py
+++ b/tests/apps_test.py
@@ -26,7 +26,6 @@ class TestE2E(unittest.TestCase):
               ad_subnet_cidr_block            = "10.1.0.0/24"
               az                              = "eu-west-2a"
               az2                             = "eu-west-2b"
-              adminpassword                   = "1234"
               ad_aws_ssm_document_name        = "1234"
               ad_writer_instance_profile_name = "1234"
               naming_suffix                   = "test-dq"

--- a/variables.tf
+++ b/variables.tf
@@ -13,9 +13,6 @@ variable "az" {
 variable "az2" {
 }
 
-variable "adminpassword" {
-}
-
 variable "ad_aws_ssm_document_name" {
 }
 


### PR DESCRIPTION
dq-tf-infra is broken.
Likely that some changes on YEL-8578 were done on console.
Attempting to resolve by removing references to `adminpassword`.