### PR TITLE
Bugfix bucket principals

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -332,7 +332,7 @@ module "ops_pipeline" {
 }
 
 module "dailytasks" {
-  source        = "github.com/UKHomeOffice/dq-tf-dailytasks?ref=bugfix-bucket-principals"
+  source        = "github.com/UKHomeOffice/dq-tf-dailytasks"
   naming_suffix = local.naming_suffix
   namespace     = var.namespace
 }

--- a/main.tf
+++ b/main.tf
@@ -332,7 +332,7 @@ module "ops_pipeline" {
 }
 
 module "dailytasks" {
-  source        = "github.com/UKHomeOffice/dq-tf-dailytasks"
+  source        = "github.com/UKHomeOffice/dq-tf-dailytasks?ref=bugfix-bucket-principals"
   naming_suffix = local.naming_suffix
   namespace     = var.namespace
 }

--- a/s3.tf
+++ b/s3.tf
@@ -13,8 +13,8 @@ resource "aws_kms_key" "bucket_key" {
             "Effect": "Allow",
             "Principal": {
                 "AWS": [
-                  "${data.aws_caller_identity.current.arn}",
-                  "${data.aws_caller_identity.current.account_id}"
+                  "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root",
+                  "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/dq-tf-infra"
                 ]
             },
             "Action": "kms:*",


### PR DESCRIPTION
It would appear that other changes were made directly on the console to satisfy security requirements in YEL-8578.
This change is to made the change in the TF code, so that dq-tf-infra can be run successfully without backing out those new security measures.
see [YEL-8750](https://jira.dsa.homeoffice.gov.uk/browse/YEL-8750?focusedCommentId=533641&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-533641)
