### PR TITLE
updated snsgb bucket iam policy

### DIFF
--- a/iam_snsgb_archive.tf
+++ b/iam_snsgb_archive.tf
@@ -19,6 +19,15 @@ resource "aws_iam_policy" "dq_snsgb_archive_bucket_policy" {
     },
     {
       "Action": [
+        "s3:*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::dsa-cdl-s3-hmrc-prod"
+      ]
+    },
+    {
+      "Action": [
         "s3:PutObject"
       ],
       "Effect": "Allow",


### PR DESCRIPTION
This PR is to update SNSGB IAM Archive bucket policy only in Notprod to access CDLZ bucket and download SNSGB files from 19-Sep.