### PR TITLE
Set Status to IAM User Access Keys

### DIFF
--- a/iam_athena_cleanup.tf
+++ b/iam_athena_cleanup.tf
@@ -111,6 +111,7 @@ resource "aws_iam_user" "athena" {
 
 resource "aws_iam_access_key" "athena" {
   user = aws_iam_user.athena.name
+  status = "Inactive"
 }
 
 resource "aws_ssm_parameter" "athena_id" {

--- a/iam_athena_cleanup.tf
+++ b/iam_athena_cleanup.tf
@@ -110,7 +110,7 @@ resource "aws_iam_user" "athena" {
 }
 
 resource "aws_iam_access_key" "athena" {
-  user = aws_iam_user.athena.name
+  user   = aws_iam_user.athena.name
   status = "Inactive"
 }
 

--- a/iam_athena_mi_user.tf
+++ b/iam_athena_mi_user.tf
@@ -101,6 +101,7 @@ resource "aws_iam_user" "athena_mi_user" {
 
 resource "aws_iam_access_key" "athena_mi_user" {
   user = aws_iam_user.athena_mi_user.name
+  status = "Inactive"
 }
 
 resource "aws_iam_group" "athena_mi_user" {

--- a/iam_athena_mi_user.tf
+++ b/iam_athena_mi_user.tf
@@ -100,7 +100,7 @@ resource "aws_iam_user" "athena_mi_user" {
 
 
 resource "aws_iam_access_key" "athena_mi_user" {
-  user = aws_iam_user.athena_mi_user.name
+  user   = aws_iam_user.athena_mi_user.name
   status = "Inactive"
 }
 

--- a/iam_data_archive.tf
+++ b/iam_data_archive.tf
@@ -3,7 +3,7 @@ resource "aws_iam_user" "data_archive_bucket" {
 }
 
 resource "aws_iam_access_key" "data_archive_bucket_v2" {
-  user = aws_iam_user.data_archive_bucket.name
+  user   = aws_iam_user.data_archive_bucket.name
   status = "Inactive"
 }
 

--- a/iam_data_archive.tf
+++ b/iam_data_archive.tf
@@ -4,6 +4,7 @@ resource "aws_iam_user" "data_archive_bucket" {
 
 resource "aws_iam_access_key" "data_archive_bucket_v2" {
   user = aws_iam_user.data_archive_bucket.name
+  status = "Inactive"
 }
 
 resource "aws_iam_group" "data_archive_bucket" {

--- a/iam_dq_data_generator.tf
+++ b/iam_dq_data_generator.tf
@@ -64,8 +64,8 @@ resource "aws_iam_user" "dq_data_generator_bucket" {
 
 
 resource "aws_iam_access_key" "dq_data_generator_bucket" {
-  count = var.namespace == "notprod" ? 1 : 0
-  user  = aws_iam_user.dq_data_generator_bucket[count.index].name
+  count  = var.namespace == "notprod" ? 1 : 0
+  user   = aws_iam_user.dq_data_generator_bucket[count.index].name
   status = "Inactive"
 }
 

--- a/iam_dq_data_generator.tf
+++ b/iam_dq_data_generator.tf
@@ -66,6 +66,7 @@ resource "aws_iam_user" "dq_data_generator_bucket" {
 resource "aws_iam_access_key" "dq_data_generator_bucket" {
   count = var.namespace == "notprod" ? 1 : 0
   user  = aws_iam_user.dq_data_generator_bucket[count.index].name
+  status = "Inactive"
 }
 
 resource "aws_iam_group" "dq_data_generator_bucket" {

--- a/iam_nats_historic_user.tf
+++ b/iam_nats_historic_user.tf
@@ -70,6 +70,7 @@ resource "aws_iam_user" "nats_history" {
 
 resource "aws_iam_access_key" "nats_history" {
   user = aws_iam_user.nats_history.name
+  status = "Inactive"
 }
 
 resource "aws_ssm_parameter" "nats_history_id" {

--- a/iam_nats_historic_user.tf
+++ b/iam_nats_historic_user.tf
@@ -69,7 +69,7 @@ resource "aws_iam_user" "nats_history" {
 }
 
 resource "aws_iam_access_key" "nats_history" {
-  user = aws_iam_user.nats_history.name
+  user   = aws_iam_user.nats_history.name
   status = "Inactive"
 }
 

--- a/iam_rds_maintenance.tf
+++ b/iam_rds_maintenance.tf
@@ -8,6 +8,7 @@ resource "aws_iam_user" "rds_maintenance" {
 
 resource "aws_iam_access_key" "rds_maintenance" {
   user = aws_iam_user.rds_maintenance.name
+  status = "Inactive"
 }
 
 resource "aws_iam_group_membership" "rds_maintenance" {

--- a/iam_rds_maintenance.tf
+++ b/iam_rds_maintenance.tf
@@ -7,7 +7,7 @@ resource "aws_iam_user" "rds_maintenance" {
 }
 
 resource "aws_iam_access_key" "rds_maintenance" {
-  user = aws_iam_user.rds_maintenance.name
+  user   = aws_iam_user.rds_maintenance.name
   status = "Inactive"
 }
 


### PR DESCRIPTION
Part of security remediation, setting status of IAM user access keys which are inactive and not used more than a 1year.

https://drone-gh.acp.homeoffice.gov.uk/UKHomeOffice/dq-tf-infra/5212/1/8

They keys which are inactive are being activated by IaC.